### PR TITLE
Structure 5: Add a title to the Jupyter notebook in Markdown

### DIFF
--- a/code/SupervisedMachineLearning.ipynb
+++ b/code/SupervisedMachineLearning.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Supervised Machine Learning: Linear & Categorical"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "pt77rlohfbC5"
    },


### PR DESCRIPTION
This adds a title header to the notebook to explain the different types of supervised learning, again making it easier to scan the document