### PR TITLE
Code Etiquette 7: Minor comment edits and adding shape of CASchools data

### DIFF
--- a/code/SupervisedMachineLearning.ipynb
+++ b/code/SupervisedMachineLearning.ipynb
@@ -232,6 +232,8 @@
     }
    ],
    "source": [
+    "# Read in the data\n",
+    "\n",
     "df = pd.read_csv('https://vincentarelbundock.github.io/Rdatasets/csv/Ecdat/Caschool.csv')\n",
     "df.head()"
    ]
@@ -302,6 +304,26 @@
     "# Visualize DataFrame info\n",
     "\n",
     "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(420, 11)"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.shape"
    ]
   },
   {
@@ -662,7 +684,7 @@
    },
    "outputs": [],
    "source": [
-    "# drop unnecessary columns\n",
+    "# Drop unnecessary columns\n",
     "\n",
     "df = df.iloc[:, 4:]"
    ]


### PR DESCRIPTION
Some minor comment edits (capitalizations, labelling an action) for readability. Added the shape of the CASchools data under the display of info as a check. It looks like the number of columns doesn't line up between the 'info' (15) and 'shape' (11) of the DataFrame. Maybe only some types of columns are counted?